### PR TITLE
Use default HTTP client

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -17,10 +17,7 @@
         <service id="beelab_paypal.gateway.express" class="Omnipay\PayPal\ExpressGateway" public="false">
             <factory service="beelab_paypal.gateway.factory" method="create"/>
             <argument>PayPal_Express</argument>
-            <argument type="service" id="beelab_paypal.guzzle.client" />
         </service>
-
-        <service id="beelab_paypal.guzzle.client" class="Guzzle\Http\Client" public="false"/>
     </services>
 
 </container>


### PR DESCRIPTION
I suggest get rid of Guzzle\Http\Client, because it is deprecated.
Also, Gateway can use default HTTP client.
https://github.com/thephpleague/omnipay-common/blob/master/src/Common/AbstractGateway.php#L67